### PR TITLE
DescribeAddresses, Making VPC mandatory in Security Group and AllocateAddress

### DIFF
--- a/ec2api/api/__init__.py
+++ b/ec2api/api/__init__.py
@@ -153,7 +153,7 @@ class EC2KeystoneAuth(wsgi.Middleware):
                           'AssociateAddress' : '',
                           'DisassociateAddress' : '',
                           'ReleaseAddress' : '',
-                          'DescribeAddress' : '',
+                          'DescribeAddresses' : '',
                         }
 
     armappingdict = {
@@ -246,7 +246,7 @@ class EC2KeystoneAuth(wsgi.Middleware):
                           'ReleaseAddress':
                                        [
                                        ],
-                          'DescribeAddress':
+                          'DescribeAddresses':
                                        [
                                        ],
                           'CreateSecurityGroup':

--- a/ec2api/api/address.py
+++ b/ec2api/api/address.py
@@ -49,7 +49,6 @@ def allocate_address(context, domain=None):
     #    msg = _("Invalid value '%(domain)s' for domain.") % {'domain': domain}
     #    raise exception.InvalidParameterValue(msg)
 
-    print domain
     if domain and domain not in ['vpc']:
         msg = _("Invalid value '%(domain)s' for domain.") % {'domain': domain}
         raise exception.InvalidParameterValue(msg)

--- a/ec2api/api/address.py
+++ b/ec2api/api/address.py
@@ -44,7 +44,13 @@ def get_address_engine():
 
 
 def allocate_address(context, domain=None):
-    if domain and domain not in ['vpc', 'standard']:
+    #Commenting below code as we are not supporting standard domain right now.
+    #if domain and domain not in ['vpc', 'standard']:
+    #    msg = _("Invalid value '%(domain)s' for domain.") % {'domain': domain}
+    #    raise exception.InvalidParameterValue(msg)
+
+    print domain
+    if domain and domain not in ['vpc']:
         msg = _("Invalid value '%(domain)s' for domain.") % {'domain': domain}
         raise exception.InvalidParameterValue(msg)
 

--- a/ec2api/api/cloud.py
+++ b/ec2api/api/cloud.py
@@ -92,8 +92,12 @@ class CloudController(object):
     def __str__(self):
         return 'CloudController'
 
+
+    #making domain ID mendatory
+    #def allocate_address(self, context, domain=None):
+
     @module_and_param_types(address, 'str255')
-    def allocate_address(self, context, domain=None):
+    def allocate_address(self, context, domain):
         """Acquires an Elastic IP address.
 
         Args:
@@ -230,10 +234,13 @@ class CloudController(object):
             A list of security groups.
         """
 
+    #Creating VPC id mandatory for Security Group
+    #In future if you want to revert change do vpc_id=None
+
     @module_and_param_types(security_group, 'security_group_str',
                             'security_group_str', 'vpc_id')
     def create_security_group(self, context, group_name,
-                              group_description, vpc_id=None):
+                              group_description, vpc_id):
         """Creates a security group.
 
         Args:


### PR DESCRIPTION
Adding change for DescribeAddresses. Also making VPC mandatory for security group and allocate address. Removing domain=standard from allocate address
