### PR TITLE
Describe by name deletes entries from ec2db

### DIFF
--- a/ec2api/api/cloud.py
+++ b/ec2api/api/cloud.py
@@ -217,10 +217,8 @@ class CloudController(object):
             A list of Elastic IP addresses.
         """
 
-    @module_and_param_types(security_group, 'security_group_strs',
-                            'sg_ids', 'filter')
-    def describe_security_groups(self, context, group_name=None,
-                                 group_id=None, filter=None):
+    @module_and_param_types(security_group, 'sg_ids', 'filter')
+    def describe_security_groups(self, context, group_id=None, filter=None):
         """Describes one or more of your security groups.
 
         Args:

--- a/ec2api/api/common.py
+++ b/ec2api/api/common.py
@@ -363,10 +363,13 @@ class UniversalDescriber(object):
             if (formatted_item and
                     not self.filtered_out(formatted_item, filter)):
                 formatted_items.append(formatted_item)
+        #JNT-37:commented obsolete delete.
+        #reason: describe by name deleting entries from ec2db
+
         # NOTE(Alex): delete obsolete items
-        for item in self.items:
-            if item['id'] not in paired_items_ids:
-                self.delete_obsolete_item(item)
+        # for item in self.items:
+        #     if item['id'] not in paired_items_ids:
+        #         self.delete_obsolete_item(item)
         # NOTE(Alex): some requested items are not found
         if self.ids or self.names:
             params = {'id': next(iter(self.ids or self.names))}

--- a/ec2api/api/security_group.py
+++ b/ec2api/api/security_group.py
@@ -164,10 +164,9 @@ class SecurityGroupDescriber(common.TaggableItemsDescriber):
         return had_to_repair
 
 
-def describe_security_groups(context, group_name=None, group_id=None,
-                             filter=None):
+def describe_security_groups(context, group_id=None, filter=None):
     formatted_security_groups = SecurityGroupDescriber().describe(
-        context, group_id, group_name, filter)
+        context, group_id, None, filter)
     return {'securityGroupInfo': formatted_security_groups}
 
 


### PR DESCRIPTION
patch summary:
- disable describe by name for security group
- commented out obsolete delete section of describe
  Closes-Bug: #JNT-37
