### PR TITLE
JNT-104: Block creating VPCs with over-lapping CIDR

### DIFF
--- a/ec2api/api/validator.py
+++ b/ec2api/api/validator.py
@@ -138,6 +138,16 @@ def validate_vpc_cidr(cidr):
     if not _validate_cidr_block(cidr):
         raise exception.InvalidVpcRange(cidr_block=cidr)
 
+def validate_vpc_cidr_overlap(cidr1, cidr2):
+    net1 = netaddr.IPNetwork(cidr1)
+    net2 = netaddr.IPNetwork(cidr2)
+    if net1.prefixlen <= net2.prefixlen:
+        if net2 in net1:
+            return False
+    else:
+        if net1 in net2:
+            return False
+    return True
 
 def validate_subnet_cidr(cidr):
     if not _validate_cidr_block(cidr):

--- a/ec2api/exception.py
+++ b/ec2api/exception.py
@@ -214,6 +214,10 @@ class InvalidVpcRange(EC2InvalidException):
     msg_fmt = _("The CIDR '%(cidr_block)s' is invalid, kindly input a netmask between /16 and /28. "
                 "Please refer VPC API Reference Guide for more details.")
 
+class OverlappedVpcRange(EC2InvalidException):
+    ec2_code = 'OverlappedVpc.Range'
+    msg_fmt = _("The CIDR '%(cidr_block)s' is overlapped with CIDR of vpc '%(vpc_id)s'.")
+
 class InvalidSubnetRange(EC2InvalidException):
     ec2_code = 'InvalidSubnet.Range'
     msg_fmt = _("The CIDR '%(cidr_block)s' is invalid, kindly input a netmask between /16 and /28. "


### PR DESCRIPTION
Block the users from creating VPCs with over-lapping CIDR within the same account
 I added this check after ec2-db commit  of vpc entry to avoid concurrency issue.
 Worst-case scenario:
        - all concurrent vpc create request (with overlapping cidr in same account) will fail.
Tested scenarios:
- Failure Testing:
  - vpc1-10.0.0.16  vpc2-10.0.0.0/24
  - vpc1-10.0.0.0/24 vpc2-10.0.0.16
- Performance and concurrency test

This patch add new exception named "OverlappedVpcRange" with code "OverlappedVpc.Range" and message "The CIDR '10.0.0.0/16' is overlapped with CIDR of vpc vpc-xxxxx'"

Closes-Bug: #JNT-104
